### PR TITLE
remove hot column from leads

### DIFF
--- a/app/views/api/v1/leads/index.json.jbuilder
+++ b/app/views/api/v1/leads/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array!  @leads.each do |lead|
   json.(lead, :id, :first_name, :last_name, :email, :phone, :ip, :city, :state,
-  :zip, :contacted, :appointment_date, :created_at, :updated_at, :processed_within_minutes, :hot)
+  :zip, :contacted, :appointment_date, :created_at, :updated_at)
   json.events lead.events, :id, :lead_id, :name, :created_at, :updated_at
 end

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -22,7 +22,6 @@
                 <th>Last Name</th>
                 <th>Email</th>
                 <th>Phone</th>
-                <th>Hot?</th>
                 <th>Appointment Date</th>
               </tr>
             </thead>
@@ -33,7 +32,6 @@
                 <td>{{ lead.last_name }}</td>
                 <td><a v-bind:href="'/leads/' + lead.id + '/edit'">{{ lead.email }}</a></td>
                 <td>{{ lead.phone }}</td>
-                <td>{{ lead.hot }}</td>
                 <td>{{ moment(lead.appointment_date).format('dddd MMM Do YYYY, h:mm a') }}</td>
               </tr>
             </tbody>


### PR DESCRIPTION
hey, we removed the hot column!

[trello card feature 148](https://trello.com/c/fT2EEPYB/12-148-remove-the-hot-column-from-the-leads-index-page)

![](https://trello-attachments.s3.amazonaws.com/5c99635463f57b322b101a4c/5c99635463f57b322b101a5e/54ac7f323f6785abba4abc72c93257ea/Screen_Shot_2019-04-01_at_6.36.44_PM.png)