### PR TITLE
show history in all leads table when click on a lead

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -16,6 +16,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
     methods: {
       moment: function(date) {
         return moment(date);
+      },
+      showEvents:  function(lead) {
+        document.getElementById(lead.id).classList.add("show");
       }
     },
     computed: {

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -27,15 +27,27 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="lead in leads">
-                <td>{{ moment(lead.created_at).format('dddd MMM Do YYYY, h:mm a') }}</td>
-                <td>{{ lead.first_name }}</td>
-                <td>{{ lead.last_name }}</td>
-                <td><a v-bind:href="'/leads/' + lead.id + '/edit'">{{ lead.email }}</a></td>
-                <td>{{ lead.phone }}</td>
-                <td>{{ moment(lead.appointment_date).format('dddd MMM Do YYYY, h:mm a') }}</td>
-                <td> {{ lead.notes }}</td>
-              </tr>
+              <template v-for="lead in leads">
+                <tr @click="showEvents(lead)">
+                  <td>{{ moment(lead.created_at).format('dddd MMM Do YYYY, h:mm a') }}</td>
+                  <td>{{ lead.first_name }}</td>
+                  <td>{{ lead.last_name }}</td>
+                  <td><a v-bind:href="'/leads/' + lead.id + '/edit'">{{ lead.email }}</a></td>
+                  <td>{{ lead.phone }}</td>
+                  <td>{{ moment(lead.appointment_date).format('dddd MMM Do YYYY, h:mm a') }}</td>
+                  <td> {{ lead.notes }}</td>
+                </tr>
+                <tr :id = "lead.id" class = "collapse">
+                  <td colspan = "7">
+                    <div v-for= "event in lead.events" style="font-size:20px; font-weight: bold;">
+                      <p>
+                        <span style="width:150px;">{{ event.name }}</span>
+                        <span>{{ moment(event.created_at).format('dddd MMM Do YYYY, h:mm a') }}</span>
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              </template>
             </tbody>
           </table>
         </div>

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -39,7 +39,7 @@
                 </tr>
                 <tr :id = "lead.id" class = "collapse">
                   <td colspan = "7">
-                    <div v-for= "event in lead.events" style="font-size:20px; font-weight: bold;">
+                    <div v-for= "event in lead.events" style="font-size:15px; font-weight: bold;">
                       <p>
                         <span style="width:150px;">{{ event.name }}</span>
                         <span>{{ moment(event.created_at).format('dddd MMM Do YYYY, h:mm a') }}</span>


### PR DESCRIPTION
added a dropdown that shows individual leads activity when clicked in the all leads table. 

![](https://trello-attachments.s3.amazonaws.com/5c99635463f57b322b101a4c/5c99635463f57b322b101a58/bc8f80bece827f7b40dbe1e11a9b4fa1/Screen_Shot_2019-04-04_at_7.41.56_PM.png)
